### PR TITLE
Add the damage and loss model library as a submodule in pelicun.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "pelicun/resources/DamageAndLossModelLibrary"]
+	path = pelicun/resources/DamageAndLossModelLibrary
+	url = https://github.com/NHERI-SimCenter/DamageAndLossModelLibrary


### PR DESCRIPTION
This PR adds the damage and loss model library as a submodule in pelicun.
The commands used to do this are documented in the commit message.
Currently this is the only change.

Following steps:
- [ ] Update the `PelicunDefault/` paths with a backwards compatible approach.
- [ ] Remove the existing library files under `resources/SimCenterDBDL` and begin relying on the submodule.
- [ ] Ensure the package build script properly includes the submodule's files so that they are available to users installing from PyPI.
