### PR TITLE
Add option to set assessment options with auto populated configs

### DIFF
--- a/pelicun/base.py
+++ b/pelicun/base.py
@@ -179,12 +179,9 @@ class Options:
         self.sampling_method = None
         self.list_all_ds = None
 
-        self._seed = None
-
-        self._rng = np.random.default_rng()
         merged_config_options = merge_default_config(user_config_options)
 
-        self._seed = merged_config_options['Seed']
+        self.seed = merged_config_options['Seed']
         self.sampling_method = merged_config_options['Sampling']['SamplingMethod']
         self.list_all_ds = merged_config_options['ListAllDamageStates']
 

--- a/pelicun/tools/DL_calculation.py
+++ b/pelicun/tools/DL_calculation.py
@@ -57,6 +57,7 @@ from pelicun.base import describe
 from pelicun.base import EDP_to_demand_type
 from pelicun.file_io import load_data
 from pelicun.assessment import Assessment
+from pelicun.base import update_vals
 
 
 # this is exceptional code
@@ -388,6 +389,25 @@ def run_pelicun(
                 )
 
                 return 0
+
+            # look for possibly specified assessment options
+            try:
+                assessment_options = config['Applications']['DL']['ApplicationData'][
+                    'Options'
+                ]
+            except KeyError:
+                assessment_options = None
+
+            if assessment_options:
+                # extend options defined via the auto-population script to
+                # include those in the original `config`
+                config_ap['Applications']['DL']['ApplicationData'].pop('Options')
+                update_vals(
+                    config_ap['DL']['Options'],
+                    assessment_options,
+                    "config_ap['DL']['Options']",
+                    'assessment_options',
+                )
 
             # add the demand information
             config_ap['DL']['Demands'].update(


### PR DESCRIPTION
- Adds the option to set the seed and other assessment options in cases where DL_calculation input files (config files) are auto-populated.
- Fixes a bug on setting the seed in the assessment options object.