### PR TITLE
Fix warning messages triggered by our own code.

### DIFF
--- a/pelicun/assessment.py
+++ b/pelicun/assessment.py
@@ -1373,8 +1373,8 @@ class DLCalculationAssessment(AssessmentBase):
 
         # prepare additional loss map entries, if needed
         if 'DMG-collapse' not in loss_map.index:
-            loss_map.loc['DMG-collapse', 'Repair'] = 'replacement'
-            loss_map.loc['DMG-irreparable', 'Repair'] = 'replacement'
+            loss_map.loc['collapse', 'Repair'] = 'replacement'
+            loss_map.loc['irreparable', 'Repair'] = 'replacement'
 
         if decision_variables:
             self.loss.decision_variables = decision_variables
@@ -1916,7 +1916,7 @@ def _loss__map_auto(
                 continue
 
             if dmg_cmp in loss_cmps:
-                drivers.append(f'DMG-{dmg_cmp}')
+                drivers.append(dmg_cmp)
                 loss_models.append(dmg_cmp)
 
     elif dl_method in {
@@ -1936,7 +1936,7 @@ def _loss__map_auto(
                 loss_cmp = cmp_class
 
             if loss_cmp in loss_cmps:
-                drivers.append(f'DMG-{dmg_cmp}')
+                drivers.append(dmg_cmp)
                 loss_models.append(loss_cmp)
 
     return pd.DataFrame(loss_models, columns=['Repair'], index=drivers)

--- a/pelicun/assessment.py
+++ b/pelicun/assessment.py
@@ -1195,6 +1195,16 @@ class DLCalculationAssessment(AssessmentBase):
 
                     dmg_process = new_dmg_process
 
+                # Remove components not present in the asset model
+                # from the source components of the damage process.
+                asset_components = set(self.asset.list_unique_component_ids())
+                filtered_dmg_process = {}
+                for key in dmg_process:
+                    component = key.split('_')[1]
+                    if component in asset_components:
+                        filtered_dmg_process[key] = dmg_process[key]
+                dmg_process = filtered_dmg_process
+
             elif damage_process_approach == 'User Defined':
                 if damage_process_file_path is None:
                     msg = (

--- a/pelicun/base.py
+++ b/pelicun/base.py
@@ -451,7 +451,7 @@ class Logger:
         """Issues all warnings and clears the warning stack."""
         for message in self.warning_stack:
             if message not in self.emitted:
-                warnings.warn(message, PelicunWarning, stacklevel=2)
+                warnings.warn(message, PelicunWarning, stacklevel=3)
                 if self.warning_file is not None:
                     with Path(self.warning_file).open('a', encoding='utf-8') as f:
                         f.write(

--- a/pelicun/model/damage_model.py
+++ b/pelicun/model/damage_model.py
@@ -1374,6 +1374,11 @@ class DamageModel_DS(DamageModel_Base):
 
                     theta_0 = frg_params_ls.get('Theta_0', np.nan)
                     family = frg_params_ls.get('Family', 'deterministic')
+
+                    # if `family` is defined but is `None`, we
+                    # consider it to be `deterministic`
+                    if not family:
+                        family = 'deterministic'
                     ds_weights = frg_params_ls.get('DamageStateWeights', None)
 
                     # check if the limit state is defined for the component
@@ -1385,7 +1390,7 @@ class DamageModel_DS(DamageModel_Base):
                     ]
 
                     if capacity_adjustment_operation:
-                        if family in {'normal', 'lognormal'}:
+                        if family in {'normal', 'lognormal', 'deterministic'}:
                             theta[0] = self._handle_operation(
                                 theta[0],
                                 capacity_adjustment_operation[0],

--- a/pelicun/model/loss_model.py
+++ b/pelicun/model/loss_model.py
@@ -83,7 +83,7 @@ class LossModel(PelicunModel):
     def __init__(
         self,
         assessment: AssessmentBase,
-        decision_variables: tuple[str, ...] = ('Carbon', 'Cost', 'Energy', 'Time'),
+        decision_variables: tuple[str, ...] = ('Cost', 'Time'),
         dv_units: dict[str, str] | None = None,
     ) -> None:
         """

--- a/pelicun/tests/basic/test_loss_model.py
+++ b/pelicun/tests/basic/test_loss_model.py
@@ -172,7 +172,7 @@ class TestLossModel(TestPelicunModel):
         assert len(loss_model._loss_models) == 2
 
     def test_decision_variables(self, loss_model: LossModel) -> None:
-        dvs = ('Carbon', 'Cost', 'Energy', 'Time')
+        dvs = ('Cost', 'Time')
         assert loss_model.decision_variables == dvs
         assert loss_model.ds_model.decision_variables == dvs
         assert loss_model.lf_model.decision_variables == dvs
@@ -337,14 +337,15 @@ class TestLossModel(TestPelicunModel):
     ) -> None:
         # tests that aggregate losses works when there is no loss.
         loss_model = LossModel(assessment_instance)
+        loss_model.decision_variables = ('Cost', 'Time', 'Carbon', 'Energy')
         df_agg = loss_model.aggregate_losses()
         assert isinstance(df_agg, pd.DataFrame)
         pd.testing.assert_frame_equal(
             df_agg,
             pd.DataFrame(
                 {
-                    'repair_carbon': 0.0,
                     'repair_cost': 0.00,
+                    'repair_carbon': 0.0,
                     'repair_energy': 0.00,
                     'repair_time-sequential': 0.00,
                     'repair_time-parallel': 0.00,

--- a/pelicun/tests/dl_calculation/e1/test_e1.py
+++ b/pelicun/tests/dl_calculation/e1/test_e1.py
@@ -84,18 +84,17 @@ def test_dl_calculation_1(obtain_temp_dir: str) -> None:
     os.chdir(temp_dir)
 
     # run
-    with pytest.warns(PelicunWarning):
-        run_pelicun(
-            demand_file='response.csv',
-            config_path='8000-AIM.json',
-            output_path=None,
-            coupled_edp=True,
-            realizations=100,
-            auto_script_path='PelicunDefault/Hazus_Earthquake_IM.py',
-            detailed_results=False,
-            output_format=None,
-            custom_model_dir=None,
-        )
+    run_pelicun(
+        demand_file='response.csv',
+        config_path='8000-AIM.json',
+        output_path=None,
+        coupled_edp=True,
+        realizations=100,
+        auto_script_path='PelicunDefault/Hazus_Earthquake_IM.py',
+        detailed_results=False,
+        output_format=None,
+        custom_model_dir=None,
+    )
 
     #
     # Test files

--- a/pelicun/tests/dl_calculation/e1_no_autopop/test_e1.py
+++ b/pelicun/tests/dl_calculation/e1_no_autopop/test_e1.py
@@ -84,18 +84,17 @@ def test_dl_calculation_1(obtain_temp_dir: str) -> None:
     os.chdir(temp_dir)
 
     # run
-    with pytest.warns(PelicunWarning):
-        run_pelicun(
-            demand_file='response.csv',
-            config_path='8000-AIM.json',
-            output_path=None,
-            coupled_edp=True,
-            realizations=100,
-            auto_script_path=None,
-            detailed_results=False,
-            output_format=None,
-            custom_model_dir=None,
-        )
+    run_pelicun(
+        demand_file='response.csv',
+        config_path='8000-AIM.json',
+        output_path=None,
+        coupled_edp=True,
+        realizations=100,
+        auto_script_path=None,
+        detailed_results=False,
+        output_format=None,
+        custom_model_dir=None,
+    )
 
     #
     # Test files

--- a/pelicun/tests/dl_calculation/e2/test_e2.py
+++ b/pelicun/tests/dl_calculation/e2/test_e2.py
@@ -80,18 +80,17 @@ def test_dl_calculation_2(obtain_temp_dir: tuple[str, str]) -> None:
     os.chdir(temp_dir)
 
     # run
-    with pytest.warns(PelicunWarning):
-        run_pelicun(
-            demand_file='response.csv',
-            config_path='1-AIM.json',
-            output_path=None,
-            coupled_edp=True,
-            realizations=100,
-            auto_script_path='PelicunDefault/Hazus_Earthquake_Story.py',
-            detailed_results=False,
-            output_format=None,
-            custom_model_dir=None,
-        )
+    run_pelicun(
+        demand_file='response.csv',
+        config_path='1-AIM.json',
+        output_path=None,
+        coupled_edp=True,
+        realizations=100,
+        auto_script_path='PelicunDefault/Hazus_Earthquake_Story.py',
+        detailed_results=False,
+        output_format=None,
+        custom_model_dir=None,
+    )
 
     #
     # Test files

--- a/pelicun/tests/dl_calculation/e3/test_e3.py
+++ b/pelicun/tests/dl_calculation/e3/test_e3.py
@@ -78,18 +78,17 @@ def test_dl_calculation_3(obtain_temp_dir: tuple[str, str]) -> None:
     os.chdir(temp_dir)
 
     # run
-    with pytest.warns(PelicunWarning):
-        run_pelicun(
-            demand_file='response.csv',
-            config_path='170-AIM.json',
-            output_path=None,
-            coupled_edp=False,
-            realizations=100,
-            auto_script_path='PelicunDefault/Hazus_Earthquake_Story.py',
-            detailed_results=False,
-            output_format=None,
-            custom_model_dir=None,
-        )
+    run_pelicun(
+        demand_file='response.csv',
+        config_path='170-AIM.json',
+        output_path=None,
+        coupled_edp=False,
+        realizations=100,
+        auto_script_path='PelicunDefault/Hazus_Earthquake_Story.py',
+        detailed_results=False,
+        output_format=None,
+        custom_model_dir=None,
+    )
 
     #
     # Test files

--- a/pelicun/tests/dl_calculation/e4/test_e4.py
+++ b/pelicun/tests/dl_calculation/e4/test_e4.py
@@ -83,18 +83,17 @@ def test_dl_calculation_4(obtain_temp_dir: tuple[str, str]) -> None:
     os.chdir(temp_dir)
 
     # run
-    with pytest.warns(PelicunWarning):
-        run_pelicun(
-            demand_file='response.csv',
-            config_path='0-AIM.json',
-            output_path=None,
-            coupled_edp=True,
-            realizations=100,
-            auto_script_path='PelicunDefault/Hazus_Earthquake_Story.py',
-            detailed_results=False,
-            output_format=None,
-            custom_model_dir=None,
-        )
+    run_pelicun(
+        demand_file='response.csv',
+        config_path='0-AIM.json',
+        output_path=None,
+        coupled_edp=True,
+        realizations=100,
+        auto_script_path='PelicunDefault/Hazus_Earthquake_Story.py',
+        detailed_results=False,
+        output_format=None,
+        custom_model_dir=None,
+    )
 
     #
     # Test files

--- a/pelicun/tests/dl_calculation/e5/test_e5.py
+++ b/pelicun/tests/dl_calculation/e5/test_e5.py
@@ -83,18 +83,17 @@ def test_dl_calculation_5(obtain_temp_dir: tuple[str, str]) -> None:
     os.chdir(temp_dir)
 
     # run
-    with pytest.warns(PelicunWarning):
-        run_pelicun(
-            demand_file='response.csv',
-            config_path='1-AIM.json',
-            output_path=None,
-            coupled_edp=True,
-            realizations=100,
-            auto_script_path='PelicunDefault/Hazus_Earthquake_IM.py',
-            detailed_results=False,
-            output_format=None,
-            custom_model_dir=None,
-        )
+    run_pelicun(
+        demand_file='response.csv',
+        config_path='1-AIM.json',
+        output_path=None,
+        coupled_edp=True,
+        realizations=100,
+        auto_script_path='PelicunDefault/Hazus_Earthquake_IM.py',
+        detailed_results=False,
+        output_format=None,
+        custom_model_dir=None,
+    )
 
     #
     # Test files

--- a/pelicun/tests/dl_calculation/e6/test_e6.py
+++ b/pelicun/tests/dl_calculation/e6/test_e6.py
@@ -83,18 +83,17 @@ def test_dl_calculation_6(obtain_temp_dir: tuple[str, str]) -> None:
     os.chdir(temp_dir)
 
     # run
-    with pytest.warns(PelicunWarning):
-        run_pelicun(
-            demand_file='response.csv',
-            config_path='1-AIM.json',
-            output_path=None,
-            coupled_edp=True,
-            realizations=100,
-            auto_script_path='PelicunDefault/Hazus_Earthquake_IM.py',
-            detailed_results=False,
-            output_format=None,
-            custom_model_dir=None,
-        )
+    run_pelicun(
+        demand_file='response.csv',
+        config_path='1-AIM.json',
+        output_path=None,
+        coupled_edp=True,
+        realizations=100,
+        auto_script_path='PelicunDefault/Hazus_Earthquake_IM.py',
+        detailed_results=False,
+        output_format=None,
+        custom_model_dir=None,
+    )
 
     #
     # Test files

--- a/pelicun/tests/dl_calculation/e7/test_e7.py
+++ b/pelicun/tests/dl_calculation/e7/test_e7.py
@@ -95,18 +95,17 @@ def test_dl_calculation_7(obtain_temp_dir: tuple[str, str]) -> None:
     os.chdir(temp_dir)
 
     # run
-    with pytest.warns(PelicunWarning):
-        run_pelicun(
-            demand_file='response.csv',
-            config_path='1-AIM.json',
-            output_path=None,
-            coupled_edp=True,
-            realizations=100,
-            auto_script_path='auto_HU_NJ.py',
-            detailed_results=False,
-            output_format=None,
-            custom_model_dir=None,
-        )
+    run_pelicun(
+        demand_file='response.csv',
+        config_path='1-AIM.json',
+        output_path=None,
+        coupled_edp=True,
+        realizations=100,
+        auto_script_path='auto_HU_NJ.py',
+        detailed_results=False,
+        output_format=None,
+        custom_model_dir=None,
+    )
 
     # now remove the ruleset files and auto script
     for file_path in ruleset_files:

--- a/pelicun/tests/dl_calculation/e8/test_e8.py
+++ b/pelicun/tests/dl_calculation/e8/test_e8.py
@@ -94,18 +94,17 @@ def test_dl_calculation_8(obtain_temp_dir: tuple[str, str]) -> None:
     os.chdir(temp_dir)
 
     # run
-    with pytest.warns(PelicunWarning):
-        run_pelicun(
-            demand_file='response.csv',
-            config_path='1-AIM.json',
-            output_path=None,
-            coupled_edp=True,
-            realizations=100,
-            auto_script_path='auto_HU_LA.py',
-            detailed_results=False,
-            output_format=None,
-            custom_model_dir=None,
-        )
+    run_pelicun(
+        demand_file='response.csv',
+        config_path='1-AIM.json',
+        output_path=None,
+        coupled_edp=True,
+        realizations=100,
+        auto_script_path='auto_HU_LA.py',
+        detailed_results=False,
+        output_format=None,
+        custom_model_dir=None,
+    )
 
     # now remove the ruleset files and auto script
     for file_path in ruleset_files:

--- a/pelicun/tests/dl_calculation/e9/CustomDLModels/loss_map.csv
+++ b/pelicun/tests/dl_calculation/e9/CustomDLModels/loss_map.csv
@@ -1,4 +1,4 @@
-﻿,BldgRepair
-DMG-building.1,generic
-DMG-building.2,generic
-DMG-building.3andAbove,generic
+﻿,Repair
+building.1,generic
+building.2,generic
+building.3andAbove,generic

--- a/pelicun/tests/dl_calculation/e9/custom_pop.py
+++ b/pelicun/tests/dl_calculation/e9/custom_pop.py
@@ -80,7 +80,7 @@ def auto_populate(aim):
         "Damage": {"DamageProcess": "None"},
         "Demands": {},
         "Losses": {
-            "BldgRepair": {
+            "Repair": {
                 "ConsequenceDatabase": "None",
                 "ConsequenceDatabasePath": (
                     "CustomDLDataFolder/loss_repair_Tsunami.csv"

--- a/pelicun/tests/dl_calculation/e9/test_e9.py
+++ b/pelicun/tests/dl_calculation/e9/test_e9.py
@@ -94,18 +94,17 @@ def test_dl_calculation_9(obtain_temp_dir: tuple[str, str]) -> None:
     os.chdir(temp_dir)
 
     # run
-    with pytest.warns(PelicunWarning):
-        run_pelicun(
-            demand_file='response.csv',
-            config_path='3500-AIM.json',
-            output_path=None,
-            coupled_edp=True,
-            realizations=100,
-            auto_script_path='custom_pop.py',
-            detailed_results=False,
-            output_format=None,
-            custom_model_dir='./CustomDLModels',
-        )
+    run_pelicun(
+        demand_file='response.csv',
+        config_path='3500-AIM.json',
+        output_path=None,
+        coupled_edp=True,
+        realizations=100,
+        auto_script_path='custom_pop.py',
+        detailed_results=False,
+        output_format=None,
+        custom_model_dir='./CustomDLModels',
+    )
 
     # now remove the ruleset files and auto script
     for file_path in ruleset_files:


### PR DESCRIPTION
Some necessary changes related to PR #51 were held off to verify backwards compatibility. This resulted in a couple of warnings being triggered by our own code, which is of course undesirable. This PR brings in those necessary changes.