### PR TITLE
Add support for variable parameter RVs.

### DIFF
--- a/pelicun/model/asset_model.py
+++ b/pelicun/model/asset_model.py
@@ -525,14 +525,20 @@ class AssetModel(PelicunModel):
             rv_reg.add_RV(
                 uq.rv_class_map(family)(
                     name=f'CMP-{cmp[0]}-{cmp[1]}-{cmp[2]}-{cmp[3]}',  # type: ignore
-                    theta=[  # type: ignore
-                        getattr(rv_params, f'Theta_{t_i}', np.nan)
-                        for t_i in range(3)
-                    ],
-                    truncation_limits=[
-                        getattr(rv_params, f'Truncate{side}', np.nan)
-                        for side in ('Lower', 'Upper')
-                    ],
+                    theta=np.array(
+                        [
+                            value
+                            for t_i in range(3)
+                            if (value := getattr(rv_params, f'Theta_{t_i}', None))
+                            is not None
+                        ]
+                    ),
+                    truncation_limits=np.array(
+                        [
+                            getattr(rv_params, f'Truncate{side}', np.nan)
+                            for side in ('Lower', 'Upper')
+                        ]
+                    ),
                 )
             )
 

--- a/pelicun/model/damage_model.py
+++ b/pelicun/model/damage_model.py
@@ -1385,9 +1385,14 @@ class DamageModel_DS(DamageModel_Base):
                     if pd.isna(theta_0):
                         continue
 
-                    theta = [
-                        frg_params_ls.get(f'Theta_{t_i}', np.nan) for t_i in range(3)
-                    ]
+                    theta = np.array(
+                        [
+                            value
+                            for t_i in range(3)
+                            if (value := frg_params_ls.get(f'Theta_{t_i}', None))
+                            is not None
+                        ]
+                    )
 
                     if capacity_adjustment_operation:
                         if family in {'normal', 'lognormal', 'deterministic'}:
@@ -1403,10 +1408,12 @@ class DamageModel_DS(DamageModel_Base):
                                 f'Ignoring: `{cmp_loc_dir}`, which is `{family}`'
                             )
 
-                    tr_lims = [
-                        frg_params_ls.get(f'Truncate{side}', np.nan)
-                        for side in ('Lower', 'Upper')
-                    ]
+                    tr_lims = np.array(
+                        [
+                            frg_params_ls.get(f'Truncate{side}', np.nan)
+                            for side in ('Lower', 'Upper')
+                        ]
+                    )
 
                     for block_i, _ in enumerate(blocks):
                         frg_rv_tag = (

--- a/pelicun/model/demand_model.py
+++ b/pelicun/model/demand_model.py
@@ -976,16 +976,24 @@ class DemandModel(PelicunModel):
             else:
                 # all other RVs need parameters of their distributions
                 rv_reg.add_RV(
-                    uq.rv_class_map(family)(
+                    uq.rv_class_map(family)(  # type: ignore
                         name=rv_tag,
-                        theta=[  # type: ignore
-                            getattr(rv_params, f'Theta_{t_i}', np.nan)
-                            for t_i in range(3)
-                        ],
-                        truncation_limits=[
-                            getattr(rv_params, f'Truncate{side}', np.nan)
-                            for side in ('Lower', 'Upper')
-                        ],
+                        theta=np.array(
+                            [
+                                value
+                                for t_i in range(3)
+                                if (
+                                    value := getattr(rv_params, f'Theta_{t_i}', None)
+                                )
+                                is not None
+                            ]
+                        ),
+                        truncation_limits=np.array(
+                            [
+                                getattr(rv_params, f'Truncate{side}', np.nan)
+                                for side in ('Lower', 'Upper')
+                            ]
+                        ),
                     )
                 )
 

--- a/pelicun/model/loss_model.py
+++ b/pelicun/model/loss_model.py
@@ -2187,10 +2187,11 @@ class RepairModel_DS(RepairModel_Base):
 
                     ds_family = parameters.get((f'DS{ds}', 'Family'))
                     ds_theta = [
-                        parameters.get((f'DS{ds}', f'Theta_{t_i}'), np.nan)
+                        theta
                         for t_i in range(3)
+                        if (theta := parameters.get((f'DS{ds}', f'Theta_{t_i}')))
+                        is not None
                     ]
-
                     # If there is no RV family we don't need an RV
                     if ds_family is None:
                         continue
@@ -2211,8 +2212,8 @@ class RepairModel_DS(RepairModel_Base):
                                     f'{decision_variable}-{component}-'
                                     f'{ds}-{loc}-{direction}-{uid}'
                                 ),
-                                theta=ds_theta,
-                                truncation_limits=[0.0, np.nan],
+                                theta=np.array(ds_theta),
+                                truncation_limits=np.array([0.0, np.nan]),
                             )
                         )
                         rv_count += 1
@@ -2754,10 +2755,11 @@ class RepairModel_LF(RepairModel_Base):
                 continue
             family = parameters.loc['LossFunction', 'Family']
             theta = [
-                parameters.get(('LossFunction', f'Theta_{t_i}'), np.nan)
+                theta_value
                 for t_i in range(3)
+                if (theta_value := parameters.get(('LossFunction', f'Theta_{t_i}')))
+                is not None
             ]
-
             # If there is no RV family we don't need an RV
             if pd.isna(family):
                 continue
@@ -2765,7 +2767,7 @@ class RepairModel_LF(RepairModel_Base):
             # Since the first parameter is controlled by a function,
             # we use 1.0 in its place and will scale the results in a
             # later step.
-            theta[0] = 1.0
+            theta[0] = 1.0  # type: ignore
 
             # assign RVs
             rv_reg.add_RV(
@@ -2774,8 +2776,8 @@ class RepairModel_LF(RepairModel_Base):
                         f'{decision_variable}-{consequence}-'
                         f'{component}-{location}-{direction}-{uid}-{block}'
                     ),
-                    theta=theta,
-                    truncation_limits=[0.0, np.nan],
+                    theta=np.array(theta),
+                    truncation_limits=np.array([0.0, np.nan]),
                 )
             )
             rv_count += 1

--- a/pelicun/tests/basic/test_loss_model.py
+++ b/pelicun/tests/basic/test_loss_model.py
@@ -748,13 +748,13 @@ class TestRepairModel_DS(TestRepairModel_Base):
         assert isinstance(rv_reg.RV['Time-cmp.A-1-0-1-0'], uq.NormalRandomVariable)
         assert isinstance(rv_reg.RV['Cost-cmp.D-1-0-1-0'], uq.NormalRandomVariable)
         assert np.all(
-            rv_reg.RV['Cost-cmp.A-1-0-1-0'].theta[0:2] == np.array((1.0, 1.0))
+            rv_reg.RV['Cost-cmp.A-1-0-1-0'].theta[0:2] == np.array((1.0, 1.0))  # type: ignore
         )
         assert np.all(
-            rv_reg.RV['Time-cmp.A-1-0-1-0'].theta[0:2] == np.array((1.0, 1.0))
+            rv_reg.RV['Time-cmp.A-1-0-1-0'].theta[0:2] == np.array((1.0, 1.0))  # type: ignore
         )
         assert np.all(
-            rv_reg.RV['Cost-cmp.D-1-0-1-0'].theta[0:2] == np.array([1.0, 1.0])
+            rv_reg.RV['Cost-cmp.D-1-0-1-0'].theta[0:2] == np.array([1.0, 1.0])  # type: ignore
         )
         assert 'DV-cmp.A-1-0-1-0_set' in rv_reg.RV_set
         np.all(
@@ -1076,10 +1076,10 @@ class TestRepairModel_LF(TestRepairModel_Base):
             rv_reg.RV['Time-cmp.A-cmp.A-0-1-0-1'], uq.NormalRandomVariable
         )
         assert np.all(
-            rv_reg.RV['Cost-cmp.A-cmp.A-0-1-0-1'].theta[0:2] == np.array((1.0, 0.3))
+            rv_reg.RV['Cost-cmp.A-cmp.A-0-1-0-1'].theta[0:2] == np.array((1.0, 0.3))  # type: ignore
         )
         assert np.all(
-            rv_reg.RV['Time-cmp.A-cmp.A-0-1-0-1'].theta[0:2] == np.array((1.0, 0.3))
+            rv_reg.RV['Time-cmp.A-cmp.A-0-1-0-1'].theta[0:2] == np.array((1.0, 0.3))  # type: ignore
         )
         assert 'DV-cmp.A-cmp.A-0-1-0-1_set' in rv_reg.RV_set
         np.all(

--- a/pelicun/tests/basic/test_uq.py
+++ b/pelicun/tests/basic/test_uq.py
@@ -1173,7 +1173,7 @@ def test_LogNormalRandomVariable_cdf() -> None:
 
 
 def test_LogNormalRandomVariable_variable_theta_cdf() -> None:
-    rv = uq.NormalRandomVariable(
+    rv = uq.LogNormalRandomVariable(
         'test_rv',
         theta=np.array(((0.1, 1.0), (1.0, 1.0), (2.0, 1.0))),
         truncation_limits=np.array((0.20, 3.0)),
@@ -1184,12 +1184,12 @@ def test_LogNormalRandomVariable_variable_theta_cdf() -> None:
     cdf = rv.cdf(x)
 
     # assert that CDF values are correct
-    expected_cdf = (0.0, 0.12631675, 0.57618745)
+    expected_cdf = (0.0, 0.23491926, 0.75659125)
 
     assert np.allclose(cdf, expected_cdf, rtol=1e-5)
 
     # repeat without truncation limits
-    rv = uq.NormalRandomVariable(
+    rv = uq.LogNormalRandomVariable(
         'test_rv',
         theta=np.array(((0.01, 1.0), (1.0, 1.0), (2.0, 1.0))),
     )
@@ -1198,7 +1198,7 @@ def test_LogNormalRandomVariable_variable_theta_cdf() -> None:
     cdf = rv.cdf(x)
 
     # assert that CDF values are correct
-    expected_cdf = (0.15624765, 0.30853754, 0.5)
+    expected_cdf = (0.0, 0.2441086, 0.5)
     assert np.allclose(cdf, expected_cdf, rtol=1e-5)
 
 
@@ -1241,7 +1241,7 @@ def test_LogNormalRandomVariable_inverse_transform() -> None:
 
 
 def test_LogNormalRandomVariable_variable_theta_inverse_transform() -> None:
-    rv = uq.NormalRandomVariable(
+    rv = uq.LogNormalRandomVariable(
         'test_rv',
         theta=np.array(
             (
@@ -1258,9 +1258,7 @@ def test_LogNormalRandomVariable_variable_theta_inverse_transform() -> None:
     rv.uni_sample = np.array((0.5, 0.5, 0.5, 0.0, 1.0, 0.20, 0.80))
     rv.inverse_transform_sampling()
     inverse_transform = rv.sample
-    expected_result = np.array(
-        (0.1, 1.0, 2.0, -np.inf, np.inf, 0.15837877, 1.84162123)
-    )
+    expected_result = np.array((0.1, 1.0, 2.0, 0.0, np.inf, 0.43101119, 2.32012539))
     assert inverse_transform is not None
     assert np.allclose(inverse_transform, expected_result, rtol=1e-5)
 

--- a/pelicun/tests/basic/test_uq.py
+++ b/pelicun/tests/basic/test_uq.py
@@ -893,6 +893,7 @@ def test__OLS_percentiles() -> None:
 def test_NormalRandomVariable() -> None:
     rv = uq.NormalRandomVariable('rv_name', theta=np.array((0.00, 1.00)))
     assert rv.name == 'rv_name'
+    assert rv.theta is not None
     np.testing.assert_allclose(rv.theta, np.array((0.00, 1.00)))
     assert np.all(np.isnan(rv.truncation_limits))
     assert rv.RV_set is None
@@ -905,6 +906,7 @@ def test_NormalRandomVariable() -> None:
 def test_Normal_STD() -> None:
     rv = uq.Normal_STD('rv_name', theta=np.array((0.00, 1.00)))
     assert rv.name == 'rv_name'
+    assert rv.theta is not None
     np.testing.assert_allclose(rv.theta, np.array((0.00, 1.00)))
     assert np.all(np.isnan(rv.truncation_limits))
     assert rv.RV_set is None
@@ -920,6 +922,7 @@ def test_Normal_COV() -> None:
         rv = uq.Normal_COV('rv_name', theta=np.array((0.00, 1.00)))
     rv = uq.Normal_COV('rv_name', theta=np.array((2.00, 1.00)))
     assert rv.name == 'rv_name'
+    assert rv.theta is not None
     np.testing.assert_allclose(rv.theta, np.array((2.00, 2.00)))
     assert np.all(np.isnan(rv.truncation_limits))
     assert rv.RV_set is None
@@ -954,6 +957,36 @@ def test_NormalRandomVariable_cdf() -> None:
     assert np.allclose(
         cdf, (0.02275013, 0.15865525, 0.30853754, 0.5, 0.84134475), rtol=1e-5
     )
+
+
+def test_NormalRandomVariable_variable_theta_cdf() -> None:
+    rv = uq.NormalRandomVariable(
+        'test_rv',
+        theta=np.array(((0.0, 1.0), (1.0, 1.0), (2.0, 1.0))),
+        truncation_limits=np.array((0.00, np.nan)),
+    )
+
+    # evaluate CDF at different points
+    x = np.array((-1.0, 0.5, 2.0))
+    cdf = rv.cdf(x)
+
+    # assert that CDF values are correct
+    expected_cdf = (0.0, 0.1781461, 0.48836013)
+
+    assert np.allclose(cdf, expected_cdf, rtol=1e-5)
+
+    # repeat without truncation limits
+    rv = uq.NormalRandomVariable(
+        'test_rv',
+        theta=np.array(((0.0, 1.0), (1.0, 1.0), (2.0, 1.0))),
+    )
+
+    x = np.array((-1.0, 0.5, 2.0))
+    cdf = rv.cdf(x)
+
+    # assert that CDF values are correct
+    expected_cdf = (0.15865525, 0.30853754, 0.5)
+    assert np.allclose(cdf, expected_cdf, rtol=1e-5)
 
 
 def test_Normal_STD_cdf() -> None:
@@ -1057,6 +1090,31 @@ def test_NormalRandomVariable_inverse_transform() -> None:
         rv.inverse_transform_sampling()
 
 
+def test_NormalRandomVariable_variable_theta_inverse_transform() -> None:
+    rv = uq.NormalRandomVariable(
+        'test_rv',
+        theta=np.array(
+            (
+                (0.0, 1.0),
+                (1.0, 1.0),
+                (2.0, 1.0),
+                (1.0, 1.0),
+                (1.0, 1.0),
+                (1.0, 1.0),
+                (1.0, 1.0),
+            )
+        ),
+    )
+    rv.uni_sample = np.array((0.5, 0.5, 0.5, 0.0, 1.0, 0.20, 0.80))
+    rv.inverse_transform_sampling()
+    inverse_transform = rv.sample
+    expected_result = np.array(
+        (0.0, 1.0, 2.0, -np.inf, np.inf, 0.15837877, 1.84162123)
+    )
+    assert inverse_transform is not None
+    assert np.allclose(inverse_transform, expected_result, rtol=1e-5)
+
+
 def test_Normal_STD_inverse_transform() -> None:
     samples = np.array((0.10, 0.20, 0.30))
     rv = uq.Normal_STD('test_rv', theta=np.array((1.0, 0.5)))
@@ -1114,6 +1172,36 @@ def test_LogNormalRandomVariable_cdf() -> None:
     assert np.allclose(cdf, (0.0, 0.0, 0.2441086, 0.5, 0.7558914), rtol=1e-5)
 
 
+def test_LogNormalRandomVariable_variable_theta_cdf() -> None:
+    rv = uq.NormalRandomVariable(
+        'test_rv',
+        theta=np.array(((0.1, 1.0), (1.0, 1.0), (2.0, 1.0))),
+        truncation_limits=np.array((0.20, 3.0)),
+    )
+
+    # evaluate CDF at different points
+    x = np.array((0.01, 0.5, 2.0))
+    cdf = rv.cdf(x)
+
+    # assert that CDF values are correct
+    expected_cdf = (0.0, 0.12631675, 0.57618745)
+
+    assert np.allclose(cdf, expected_cdf, rtol=1e-5)
+
+    # repeat without truncation limits
+    rv = uq.NormalRandomVariable(
+        'test_rv',
+        theta=np.array(((0.01, 1.0), (1.0, 1.0), (2.0, 1.0))),
+    )
+
+    x = np.array((-1.0, 0.5, 2.0))
+    cdf = rv.cdf(x)
+
+    # assert that CDF values are correct
+    expected_cdf = (0.15624765, 0.30853754, 0.5)
+    assert np.allclose(cdf, expected_cdf, rtol=1e-5)
+
+
 def test_LogNormalRandomVariable_inverse_transform() -> None:
     samples = np.array((0.10, 0.20, 0.30))
     rv = uq.LogNormalRandomVariable('test_rv', theta=np.array((1.0, 0.5)))
@@ -1150,6 +1238,31 @@ def test_LogNormalRandomVariable_inverse_transform() -> None:
     rv = uq.LogNormalRandomVariable('test_rv', theta=np.array((1.0, 0.5)))
     with pytest.raises(ValueError, match='No available uniform sample.'):
         rv.inverse_transform_sampling()
+
+
+def test_LogNormalRandomVariable_variable_theta_inverse_transform() -> None:
+    rv = uq.NormalRandomVariable(
+        'test_rv',
+        theta=np.array(
+            (
+                (0.10, 1.0),
+                (1.0, 1.0),
+                (2.0, 1.0),
+                (1.0, 1.0),
+                (1.0, 1.0),
+                (1.0, 1.0),
+                (1.0, 1.0),
+            )
+        ),
+    )
+    rv.uni_sample = np.array((0.5, 0.5, 0.5, 0.0, 1.0, 0.20, 0.80))
+    rv.inverse_transform_sampling()
+    inverse_transform = rv.sample
+    expected_result = np.array(
+        (0.1, 1.0, 2.0, -np.inf, np.inf, 0.15837877, 1.84162123)
+    )
+    assert inverse_transform is not None
+    assert np.allclose(inverse_transform, expected_result, rtol=1e-5)
 
 
 def test_UniformRandomVariable_cdf() -> None:
@@ -1243,6 +1356,7 @@ def test_UniformRandomVariable_inverse_transform() -> None:
 def test_WeibullRandomVariable() -> None:
     rv = uq.WeibullRandomVariable('rv_name', theta=np.array((1.5, 2.0)))
     assert rv.name == 'rv_name'
+    assert rv.theta is not None
     np.testing.assert_allclose(rv.theta, np.array((1.5, 2.0)))
     assert np.all(np.isnan(rv.truncation_limits))
     assert rv.RV_set is None

--- a/pelicun/uq.py
+++ b/pelicun/uq.py
@@ -57,7 +57,7 @@ if TYPE_CHECKING:
     from pelicun.base import Logger
 
 colorama.init()
-FIRST_POSITIVE_NUMBER = 1.0e-10
+FIRST_POSITIVE_NUMBER = np.nextafter(0,1)
 
 
 def scale_distribution(

--- a/pelicun/uq.py
+++ b/pelicun/uq.py
@@ -1409,7 +1409,7 @@ class RandomVariable(BaseRandomVariable):
         assert truncation_limits is not None
 
         if truncation_limits.shape != theta.shape:
-            # Number of columns should match
+            # Number of rows should match
             if truncation_limits.shape[1] != theta.shape[1]:
                 msg = 'Incompatible `truncation_limits` value.'
                 raise ValueError(msg)
@@ -1421,7 +1421,16 @@ class RandomVariable(BaseRandomVariable):
         p_b: np.ndarray, p_a: np.ndarray
     ) -> None:
         """
-        Ensure that all probability differences are positive.
+        Ensure there is probability mass between the truncation limits.
+
+        Parameters
+        ----------
+        p_b: float
+          The probability of not exceeding the upper truncation limit 
+          based on the CDF of the random variable.
+        p_a: float
+          The probability of not exceeding the lower truncation limit 
+          based on the CDF of the random variable.
 
         Raises
         ------

--- a/pelicun/uq.py
+++ b/pelicun/uq.py
@@ -1333,7 +1333,8 @@ class RandomVariable(BaseRandomVariable):
           True if the parameters are constant, false otherwise.
 
         """
-        assert self.theta is not None
+        if self.theta is None:
+            return True
         assert self.theta.ndim in {1, 2}
         return self.theta.ndim == 1
 

--- a/pelicun/uq.py
+++ b/pelicun/uq.py
@@ -1261,7 +1261,7 @@ class RandomVariable(BaseRandomVariable):
           Set of parameters that define the Cumulative Distribution
           Function (CDF) of the variable: E.g., mean and coefficient
           of variation. Actual parameters depend on the distribution.
-          A 1D `theta` array represents fixed parameters and results
+          A 1D `theta` array represents constant parameters and results
           in realizations that are all from the same distribution.
           A 2D `theta` array represents variable parameters, meaning
           that each realization will be sampled from the distribution
@@ -1309,7 +1309,7 @@ class RandomVariable(BaseRandomVariable):
             1,
             2,
         }, 'Parameter `truncation_limits` can only be a 1D or 2D array.'
-        # 1D corresponds to fixed parameters.
+        # 1D corresponds to constant parameters.
         # 2D corresponds to variable parameters (different in each
         # realization).
 
@@ -1331,7 +1331,7 @@ class RandomVariable(BaseRandomVariable):
         Returns
         -------
         bool
-          True if the parameters are fixed, false otherwise.
+          True if the parameters are constant, false otherwise.
 
         """
         assert self.theta is not None

--- a/pelicun/uq.py
+++ b/pelicun/uq.py
@@ -57,7 +57,7 @@ if TYPE_CHECKING:
     from pelicun.base import Logger
 
 colorama.init()
-FIRST_POSITIVE_NUMBER = np.nextafter(0,1)
+FIRST_POSITIVE_NUMBER = np.nextafter(0, 1)
 
 
 def scale_distribution(
@@ -1426,10 +1426,10 @@ class RandomVariable(BaseRandomVariable):
         Parameters
         ----------
         p_b: float
-          The probability of not exceeding the upper truncation limit 
+          The probability of not exceeding the upper truncation limit
           based on the CDF of the random variable.
         p_a: float
-          The probability of not exceeding the lower truncation limit 
+          The probability of not exceeding the lower truncation limit
           based on the CDF of the random variable.
 
         Raises

--- a/pelicun/uq.py
+++ b/pelicun/uq.py
@@ -1338,7 +1338,57 @@ class RandomVariable(BaseRandomVariable):
         assert self.theta.ndim in {1, 2}
         return self.theta.ndim == 1
 
-    def _prepare_arrays(self, values: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+    def _prepare_theta_and_truncation_limit_arrays(
+        self, values: np.ndarray
+    ) -> tuple[np.ndarray, np.ndarray]:
+        """
+        Prepare the `theta` and `truncation_limits` arrays.
+
+        Prepare the `theta` and `truncation_limits` arrays for use in
+        calculations. This method adjusts the shape and size of the
+        `theta` and `truncation_limits` attributes to ensure
+        compatibility with the provided `values` array. The
+        adjustments enable support for two approaches:
+        * Constant parameters: The parameters remain the same
+        across all realizations.
+        * Variable parameters: The parameters vary across
+        realizations.
+
+        Depending on whether the random variable uses constant or
+        variable parameters, the method ensures that the arrays are
+        correctly sized and broadcasted as needed.
+
+        Parameters
+        ----------
+        values : np.ndarray
+            Array of values for which the `theta` and
+            `truncation_limits` need to be prepared. The size of
+            `values` determines how the attributes are adjusted.
+
+        Returns
+        -------
+        tuple
+            A tuple containing:
+            * `theta` (np.ndarray): Adjusted array of parameters.
+            * `truncation_limits` (np.ndarray): Adjusted array of
+            truncation limits.
+
+        Raises
+        ------
+        ValueError
+            If the number of elements in `values` does not match the
+            number of rows of the `theta` attribute or if the
+            `truncation_limits` array is incompatible with the `theta`
+            array.
+
+        Notes
+        -----
+        The method ensures that `truncation_limits` are broadcasted to
+        match the shape of `theta` if needed. For constant parameters,
+        a single-row `theta` is expanded to a 2D array. For variable
+        parameters, the number of rows in `theta` must match the size
+        of `values`.
+        """
         theta = self.theta
         assert theta is not None
         truncation_limits = self.truncation_limits
@@ -1483,7 +1533,9 @@ class NormalRandomVariable(RandomVariable):
           1D float ndarray containing CDF values
 
         """
-        theta, truncation_limits = self._prepare_arrays(values)
+        theta, truncation_limits = self._prepare_theta_and_truncation_limit_arrays(
+            values
+        )
         mu, sig = theta.T
 
         if np.any(~np.isnan(self.truncation_limits)):
@@ -1534,7 +1586,9 @@ class NormalRandomVariable(RandomVariable):
           too small
 
         """
-        theta, truncation_limits = self._prepare_arrays(values)
+        theta, truncation_limits = self._prepare_theta_and_truncation_limit_arrays(
+            values
+        )
         mu, sig = theta.T
 
         if np.any(~np.isnan(self.truncation_limits)):
@@ -1670,7 +1724,9 @@ class LogNormalRandomVariable(RandomVariable):
           1D float ndarray containing CDF values
 
         """
-        theta, truncation_limits = self._prepare_arrays(values)
+        theta, truncation_limits = self._prepare_theta_and_truncation_limit_arrays(
+            values
+        )
         theta, beta = theta.T
 
         if np.any(~np.isnan(self.truncation_limits)):
@@ -1718,7 +1774,9 @@ class LogNormalRandomVariable(RandomVariable):
           Inverse CDF values
 
         """
-        theta, truncation_limits = self._prepare_arrays(values)
+        theta, truncation_limits = self._prepare_theta_and_truncation_limit_arrays(
+            values
+        )
         theta, beta = theta.T
 
         if np.any(~np.isnan(self.truncation_limits)):

--- a/pelicun/uq.py
+++ b/pelicun/uq.py
@@ -57,7 +57,7 @@ if TYPE_CHECKING:
     from pelicun.base import Logger
 
 colorama.init()
-SMALL_NUMBER = 1.0e-10
+FIRST_POSITIVE_NUMBER = 1.0e-10
 
 
 def scale_distribution(
@@ -516,7 +516,7 @@ def _mvn_scale(x: np.ndarray, rho: np.ndarray) -> np.ndarray:
     rho_0 = np.eye(n_dims, n_dims)
 
     a = mvn.pdf(x, mean=np.zeros(n_dims), cov=rho_0)
-    a[a < SMALL_NUMBER] = SMALL_NUMBER
+    a[a < FIRST_POSITIVE_NUMBER] = FIRST_POSITIVE_NUMBER
 
     b = mvn.pdf(x, mean=np.zeros(n_dims), cov=rho)
 
@@ -1429,7 +1429,7 @@ class RandomVariable(BaseRandomVariable):
           If a negative probability difference is found.
 
         """
-        if np.any((p_b - p_a) < SMALL_NUMBER):
+        if np.any((p_b - p_a) < FIRST_POSITIVE_NUMBER):
             msg = (
                 'The probability mass within the truncation limits is '
                 'too small and the truncated distribution cannot be '

--- a/pelicun/uq.py
+++ b/pelicun/uq.py
@@ -1793,7 +1793,7 @@ class LogNormalRandomVariable(RandomVariable):
 
             # Replace NaN values
             a = np.nan_to_num(a, nan=np.nextafter(0, 1))
-            a[a == 0] = np.nextafter(0, 1)
+            a[a < 0] = np.nextafter(0, 1)
             b = np.nan_to_num(b, nan=np.inf)
 
             p_a, p_b = (


### PR DESCRIPTION
Now RVs in the UQ module support variable parameters, meaning that in each realization a value can be drawn from the same family but with predefined parameters that differ between realizations.

The implementation envisions support for multiple RV classes, but currently only Normal and LogNormal support variable parameters.