### PR TITLE
chore: bump version to 3.9.0.dev0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pelicun"
-version = "3.8.0"
+version = "3.9.0.dev0"
 description = "Probabilistic Estimation of Losses, Injuries, and Community resilience Under Natural hazard events"
 readme = "README.md"
 license = {text = "BSD-3-Clause"}


### PR DESCRIPTION
Update version from 3.8.0 to 3.9.0.dev0 to begin development cycle for the next minor release. This prepares the codebase for new feature development and testing in the v3.9 release cycle.